### PR TITLE
updating httparty version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2016-01-05: v0.1.1
+
+* Bump HTTParty Gem Version requirement
+
 # 2013-03-16: v0.1.0
 
 * Add support for user session destruction and token validation and

--- a/crowd_rest.gemspec
+++ b/crowd_rest.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'httparty', '~>0.10.2'
+  s.add_dependency 'httparty', '~> 0.13.0'
 
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'vcr', '~>1.0'


### PR DESCRIPTION
This PR is to update HTTParty gem as other gems in the wild tend to require later versions making this gem incompatible. (HTTParty 0.10.x was released in 2013)